### PR TITLE
add circle and encircle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,59 @@
 # Bonfire.Data.AccessControl
 
+Bonfire has a slightly unusual way of dealing with access control.
+It's not so different from role-based access control (RBAC), but we do
+a few things differently and there are quite a lot of pieces to get
+your head around. We'll start gently.
+
+Bonfire has a `Verb` table containing strings like "comment" and
+"delete" that represent actions a user might wish to perform. They are
+a basic part of the bonfire vocabulary within the codebase.
+
+A `Permission` is a decision about whether the action may be performed
+it not. There are 3 decisions we support:
+
+* `true` (permitted)
+* `false` (explicitly not permitted, never permit)
+* `null`/`nil` (not explicitly permitted)
+
+It may seem odd to have the `null` here. We will come back to this
+after we've introduced a few more pieces of the puzzle.
+
+A `Boundary` is simply an unordered list or group of `Permission`s. Each
+`Permission` may only occur once. Any `Permission`s that are not specified
+are assumed to be `null`. This loosely corresponds to a `role` in RBAC.
+
+A `Grant` links a `subject` (user or circle) to a `Boundary`. It
+determines what permissions are considered for a given subject.
+
+A `Acl` is simply an unordered list or group of `Grant`s. Subjects may
+appear more than once in a list (with different boundaries) and the
+permissions will be merged according to the following truth table:
+
+| input | input | output |
+|-------|-------|--------|
+| false | false | false  |
+| false | true  | false  |
+| false | null  | false  |
+| true  | false | false  |
+| true  | true  | true   |
+| true  | null  | true   |
+| null  | false | false  |
+| null  | true  | true   |
+| null  | null  | null   |
+
+Or in words: take the highest value where `false > true > null`.
+
+At the end of this combination process, the user is only permitted if
+the result is true. You can see this as requiring an affirmative
+answer to permit something, while always allowing you a bigger `no` to
+deny when things are combined. Null values are additionally not
+required to be present in the database, saving us resources. That is
+to say we default to null if there is no relevant record.
+
+Finally, the `Controlled` mixin is used to determine which `Acl` is
+considered when determining permissions.
+
 ## Copyright and License
 
 Copyright (c) 2020 James Laver, `bonfire_data_access_control` Contributors

--- a/lib/circle.ex
+++ b/lib/circle.ex
@@ -1,0 +1,29 @@
+defmodule Bonfire.Data.AccessControl.Circle do
+  @moduledoc """
+  """
+
+  use Pointers.Virtual,
+    otp_app: :bonfire_data_access_control,
+    table_id: "41RC1ESAREAV1S1B111TYSC0PE",
+    source: "bonfire_data_access_control_circle"
+
+  alias Bonfire.Data.AccessControl.{Circle, Encircle}
+  alias Ecto.Changeset
+
+  virtual_schema do
+    has_many :encircles, Encircle, on_replace: :delete_if_exists
+  end
+
+  def changeset(circle \\ %Circle{}, params) do
+    Changeset.cast(circle, params, [])
+  end
+
+end
+defmodule Bonfire.Data.AccessControl.Circle.Migration do
+
+  import Pointers.Migration
+  alias Bonfire.Data.AccessControl.Circle
+
+  def migrate_circle(), do: migrate_virtual(Circle)
+
+end

--- a/lib/encircle.ex
+++ b/lib/encircle.ex
@@ -1,0 +1,101 @@
+defmodule Bonfire.Data.AccessControl.Encircle do
+  @moduledoc """
+  """
+
+  use Pointers.Pointable,
+    otp_app: :bonfire_data_access_control,
+    table_id: "1NSERTSAP01NTER1NT0AC1RC1E",
+    source: "bonfire_data_access_control_encircle"
+
+  alias Bonfire.Data.AccessControl.{Circle, Encircle}
+  alias Ecto.Changeset
+  alias Pointers.Pointer
+
+  pointable_schema do
+    belongs_to :subject, Pointer
+    belongs_to :circle, Pointer
+  end
+
+  @cast     [:subject_id, :circle_id]
+  @required [:circle_id]
+  @unique_index [:subject_id, :circle_id]
+
+  def changeset(encircle \\ %Encircle{}, params) do
+    encircle
+    |> Changeset.cast(params, @cast)
+    |> Changeset.validate_required(@required)
+    |> Changeset.assoc_constraint(:subject)
+    |> Changeset.assoc_constraint(:circle)
+    |> Changeset.unique_constraint(@unique_index)
+  end
+
+end
+defmodule Bonfire.Data.AccessControl.Encircle.Migration do
+
+  use Ecto.Migration
+  import Pointers.Migration
+  alias Bonfire.Data.AccessControl.Encircle
+
+  @encircle_table Encircle.__schema__(:source)
+  @unique_index [:subject_id, :circle_id]
+
+  # create_encircle_table/{0,1}
+
+  defp make_encircle_table(exprs) do
+    quote do
+      require Pointers.Migration
+      Pointers.Migration.create_pointable_table(Bonfire.Data.AccessControl.Encircle) do
+        Ecto.Migration.add :subject_id,
+          Pointers.Migration.strong_pointer()
+        Ecto.Migration.add :circle_id,
+          Pointers.Migration.strong_pointer()
+        unquote_splicing(exprs)
+      end
+    end
+  end
+
+  defmacro create_encircle_table(), do: make_encircle_table([])
+  defmacro create_encircle_table([do: {_, _, body}]), do: make_encircle_table(body)
+
+  def drop_encircle_table(), do: drop_pointable_table(Encircle)
+
+
+  def migrate_encircle_unique_index(dir \\ direction(), opts \\ [])
+  def migrate_encircle_unique_index(:up, opts),
+    do: create_if_not_exists(index(@encircle_table, @unique_index, opts))
+  def migrate_encircle_unique_index(:down, opts),
+    do: drop_if_exists(index(@encircle_table, @unique_index, opts))
+
+  def migrate_encircle_circle_index(dir \\ direction(), opts \\ [])
+  def migrate_encircle_circle_index(:up, opts),
+    do: create_if_not_exists(index(@encircle_table, [:circle_id], opts))
+  def migrate_encircle_circle_index(:down, opts),
+    do: drop_if_exists(index(@encircle_table, [:circle_id], opts))
+
+
+  defp me(:up) do
+    quote do
+      Bonfire.Data.AccessControl.Encircle.Migration.create_encircle_table()
+      Bonfire.Data.AccessControl.Encircle.Migration.migrate_encircle_unique_index()
+      Bonfire.Data.AccessControl.Encircle.Migration.migrate_encircle_circle_index()
+    end
+  end
+
+  defp me(:down) do
+    quote do
+      Bonfire.Data.AccessControl.Encircle.Migration.migrate_encircle_circle_index()
+      Bonfire.Data.AccessControl.Encircle.Migration.migrate_encircle_unique_index()
+      Bonfire.Data.AccessControl.Encircle.Migration.drop_encircle_table()
+    end
+  end
+
+  defmacro migrate_encircle() do
+    quote do
+      if Ecto.Migration.direction() == :up,
+        do: unquote(me(:up)),
+        else: unquote(me(:down))
+    end
+  end
+  defmacro migrate_encircle(dir), do: me(dir)
+
+end


### PR DESCRIPTION
circle and encircle were previously in bonfire_data_social, which bonfire_boundaries did not depend on, but actually used quietly anyway....